### PR TITLE
Fix crash when package 'net.osmand.plus' is not present

### DIFF
--- a/app/src/main/java/com/blackboxembedded/WunderLINQ/NavAppHelper.java
+++ b/app/src/main/java/com/blackboxembedded/WunderLINQ/NavAppHelper.java
@@ -392,6 +392,8 @@ public class NavAppHelper {
     }
 
     static private boolean isCallable(Activity activity, Intent intent) {
+        if(intent == null) return false;
+        
         List<ResolveInfo> list = activity.getPackageManager().queryIntentActivities(intent,
                 PackageManager.MATCH_DEFAULT_ONLY);
         return list.size() > 0;


### PR DESCRIPTION
When the package '**net.osmand.plus**' is not present the variable `navIntent` is null.
Use of null `intent` in the method `isCallable()` cause an application crash.